### PR TITLE
Add backtesting interface and FinanceDatabase symbol search

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ matplotlib
 seaborn  # For enhanced plotting (optional)
 scikit-learn  # Preparing for Phase 2 ML integration
 jupyter  # For analysis notebooks
+financedatabase

--- a/symbol_search.py
+++ b/symbol_search.py
@@ -1,0 +1,33 @@
+from financedatabase import Equities
+from functools import lru_cache
+import pandas as pd
+
+@lru_cache(maxsize=1)
+def _load_equities() -> pd.DataFrame:
+    """Load equity database for India once and cache it."""
+    eq = Equities()
+    return eq.select(country="India")
+
+def search_symbols(query: str, limit: int = 10) -> pd.DataFrame:
+    """Search Indian equities by symbol or name.
+
+    Parameters
+    ----------
+    query: str
+        Substring to search for.
+    limit: int
+        Maximum number of results to return.
+    """
+    if not query:
+        return pd.DataFrame()
+    df = _load_equities()
+    mask = df.index.str.contains(query, case=False) | df["name"].str.contains(query, case=False)
+    return df[mask].head(limit)
+
+def to_fyers_symbol(symbol: str) -> str:
+    """Convert FinanceDatabase symbol to Fyers format."""
+    if symbol.endswith(".NS"):
+        return f"NSE:{symbol[:-3]}-EQ"
+    if symbol.endswith(".BO"):
+        return f"BSE:{symbol[:-3]}-EQ"
+    return symbol

--- a/templates/backtest.html
+++ b/templates/backtest.html
@@ -1,0 +1,70 @@
+<!doctype html>
+<html>
+<head>
+  <title>Strategy Backtest</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="p-4">
+  <div class="container">
+    <h1 class="mb-4">Strategy Backtest</h1>
+    <form method="post" class="row g-3">
+      <div class="col-md-3">
+        <label class="form-label">Symbol</label>
+        <input name="symbol" class="form-control" value="{{ symbol }}" list="symbol-suggestions">
+        <datalist id="symbol-suggestions"></datalist>
+      </div>
+      <div class="col-md-3">
+        <label class="form-label">Resolution</label>
+        <select name="resolution" class="form-select">
+          {% for code, label in resolutions %}
+            <option value="{{ code }}" {% if code == default_resolution %}selected{% endif %}>{{ label }}</option>
+          {% endfor %}
+        </select>
+      </div>
+      <div class="col-md-3">
+        <label class="form-label">Start Date</label>
+        <input type="date" name="start_date" class="form-control" value="{{ start_date }}">
+      </div>
+      <div class="col-md-3">
+        <label class="form-label">End Date</label>
+        <input type="date" name="end_date" class="form-control" value="{{ end_date }}">
+      </div>
+      <div class="col-12">
+        <button class="btn btn-primary">Run Backtest</button>
+      </div>
+    </form>
+
+    {% if performance %}
+    <h2 class="mt-5">Performance</h2>
+    <table class="table table-striped">
+      <tr><th>Total Return</th><td>{{ '{:.2%}'.format(performance['total_return']) }}</td></tr>
+      <tr><th>Annual Return</th><td>{{ '{:.2%}'.format(performance['annual_return']) }}</td></tr>
+      <tr><th>Volatility</th><td>{{ '{:.2%}'.format(performance['volatility']) }}</td></tr>
+      <tr><th>Sharpe Ratio</th><td>{{ '{:.3f}'.format(performance['sharpe_ratio']) }}</td></tr>
+      <tr><th>Max Drawdown</th><td>{{ '{:.2%}'.format(performance['max_drawdown']) }}</td></tr>
+      <tr><th>Win Rate</th><td>{{ '{:.2%}'.format(performance['win_rate']) }}</td></tr>
+      <tr><th>Profit Factor</th><td>{{ '{:.2f}'.format(performance['profit_factor']) }}</td></tr>
+      <tr><th>Total Trades</th><td>{{ performance['total_trades'] }}</td></tr>
+    </table>
+    {% endif %}
+  </div>
+
+  <script>
+  const input = document.querySelector('input[name="symbol"]');
+  input.addEventListener('input', async () => {
+    const q = input.value;
+    if (q.length < 2) return;
+    const res = await fetch(`/search-symbol?q=${q}`);
+    const data = await res.json();
+    const dl = document.getElementById('symbol-suggestions');
+    dl.innerHTML = '';
+    data.forEach(item => {
+      const opt = document.createElement('option');
+      opt.value = item.symbol;
+      opt.text = `${item.symbol} - ${item.name}`;
+      dl.appendChild(opt);
+    });
+  });
+  </script>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -33,8 +33,9 @@
                 <div class="col-md-6">
                   <div class="mb-3">
                     <label class="form-label">Symbol</label>
-                    <input name="symbol" class="form-control" value="{{ default_symbol }}" 
+                    <input id="symbolInput" name="symbol" class="form-control" value="{{ default_symbol }}" list="symbol-suggestions"
                            placeholder="e.g., NSE:RELIANCE-EQ">
+                    <datalist id="symbol-suggestions"></datalist>
                     <small class="form-text text-muted">Enter the symbol you want to analyze</small>
                   </div>
                 </div>
@@ -163,7 +164,24 @@
       form.action = '/';
       form.method = 'post';
       historicOptions.style.display = 'block';
+  });
+
+  // Symbol search suggestions
+  const symbolInput = document.getElementById('symbolInput');
+  const suggestions = document.getElementById('symbol-suggestions');
+  symbolInput.addEventListener('input', async () => {
+    const q = symbolInput.value;
+    if (q.length < 2) return;
+    const res = await fetch(`/search-symbol?q=${q}`);
+    const data = await res.json();
+    suggestions.innerHTML = '';
+    data.forEach(item => {
+      const opt = document.createElement('option');
+      opt.value = item.symbol;
+      opt.text = `${item.symbol} - ${item.name}`;
+      suggestions.appendChild(opt);
     });
+  });
 
     liveOpt.addEventListener('change', () => {
       form.action = '/live';


### PR DESCRIPTION
## Summary
- add Flask endpoint to backtest strategies using existing StrategyBacktester
- integrate FinanceDatabase for symbol search with mapping to Fyers symbols
- expose symbol suggestions in dashboard and create dedicated backtest page

## Testing
- `python -m py_compile app.py symbol_search.py strategy/backtesting.py`
- `python - <<'PY'
from symbol_search import search_symbols, to_fyers_symbol
print(search_symbols('RELIANCE').head())
print(to_fyers_symbol('RELIANCE.NS'))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68adb313a6388325be9320c57b275784