### PR TITLE
Add backtesting interface and FinanceDatabase symbol search

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,6 @@
-from flask import Flask, render_template, request, flash, redirect, url_for
+from flask import Flask, render_template, request, flash, redirect, url_for, jsonify
 import pandas as pd
-from datetime import datetime, time
+from datetime import datetime, time, timedelta
 import os
 from config import (
     SYMBOL, RESOLUTIONS, DEFAULT_RESOLUTION, NUM_CANDLES, FLASK_SECRET_KEY,
@@ -10,6 +10,8 @@ from fyers_api import initialize_fyers, get_historical_data, get_historical_rang
 from indicators.composite import calculate_composite_indicators
 from strategy.signals import WeightedSignalGenerator
 from strategy.weights import WeightManager
+from strategy.backtesting import StrategyBacktester
+from symbol_search import search_symbols, to_fyers_symbol
 from plotter import save_chart
 
 app = Flask(__name__)
@@ -19,6 +21,7 @@ app.secret_key = FLASK_SECRET_KEY
 fyers = initialize_fyers()
 weight_manager = WeightManager()
 signal_generator = WeightedSignalGenerator(weight_manager)
+backtester = StrategyBacktester()
 
 # Ensure static images folder exists
 IMG_FOLDER = os.path.join(app.static_folder, 'charts')
@@ -44,7 +47,11 @@ def index():
         market_close = datetime.combine(day, time(15, 30))
 
         # Fetch historical data
-        df = get_historical_range(fyers, symbol, resolution, market_open, market_close)
+        try:
+            df = get_historical_range(fyers, symbol, resolution, market_open, market_close)
+        except RuntimeError as e:
+            flash(str(e))
+            return redirect(url_for('index'))
         if df.empty:
             flash(f'No data for {symbol} on {date_str} at {resolution} resolution.')
             return redirect(url_for('index'))
@@ -114,7 +121,11 @@ def live_view():
     show_chart = request.args.get('show_chart') == 'on'
 
     # Fetch recent data
-    df = get_historical_data(fyers, symbol, resolution, NUM_CANDLES)
+    try:
+        df = get_historical_data(fyers, symbol, resolution, NUM_CANDLES)
+    except RuntimeError as e:
+        flash(str(e))
+        return redirect(url_for('index'))
     if df.empty:
         flash(f'No live data for {symbol} at {resolution} resolution.')
         return redirect(url_for('index'))
@@ -202,6 +213,80 @@ def weights_management():
                            symbol=symbol,
                            weights=current_weights,
                            available_symbols=['default', 'NSE:RELIANCE-EQ', 'NSE:TCS-EQ'])
+
+
+@app.route('/search-symbol')
+def search_symbol_endpoint():
+    """Provide symbol suggestions based on FinanceDatabase."""
+    query = request.args.get('q', '')
+    results = []
+    if query:
+        df = search_symbols(query)
+        for sym, row in df.iterrows():
+            results.append({'symbol': to_fyers_symbol(sym), 'name': row.get('name', '')})
+    return jsonify(results)
+
+
+@app.route('/backtest', methods=['GET', 'POST'])
+def backtest_view():
+    """Run a strategy backtest over a date range."""
+    if request.method == 'POST':
+        symbol = request.form.get('symbol') or SYMBOL
+        resolution = request.form.get('resolution') or DEFAULT_RESOLUTION
+        start_date = request.form.get('start_date')
+        end_date = request.form.get('end_date')
+
+        if not start_date or not end_date:
+            flash('Please select start and end dates.')
+            return redirect(url_for('backtest_view'))
+
+        start_dt = datetime.strptime(start_date, '%Y-%m-%d')
+        end_dt = datetime.strptime(end_date, '%Y-%m-%d') + timedelta(days=1)
+
+        try:
+            df = get_historical_range(fyers, symbol, resolution, start_dt, end_dt)
+        except RuntimeError as e:
+            flash(str(e))
+            return redirect(url_for('backtest_view'))
+        if df.empty:
+            flash(f'No data for {symbol} in selected range.')
+            return redirect(url_for('backtest_view'))
+
+        df_ind = calculate_composite_indicators(
+            df,
+            basic_config=BASIC_INDICATORS_CONFIG,
+            advanced_config=ADVANCED_INDICATORS_CONFIG
+        )
+
+        signals = []
+        prices = df_ind['close'].tolist()
+        for i in range(len(df_ind)):
+            sig, _ = signal_generator.evaluate_conditions(df_ind.iloc[:i+1], symbol)
+            if sig is True:
+                signals.append('BUY')
+            elif sig is False:
+                signals.append('SELL')
+            else:
+                signals.append('NEUTRAL')
+
+        result = backtester.backtest_strategy(df_ind, signals, prices)
+
+        return render_template(
+            'backtest.html',
+            symbol=symbol,
+            resolution=resolution,
+            start_date=start_date,
+            end_date=end_date,
+            performance=result.get('performance'),
+            resolutions=RESOLUTIONS,
+            default_resolution=DEFAULT_RESOLUTION
+        )
+
+    # GET request - show backtest form
+    return render_template('backtest.html',
+                           symbol=SYMBOL,
+                           resolutions=RESOLUTIONS,
+                           default_resolution=DEFAULT_RESOLUTION)
 
 
 if __name__ == '__main__':

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ matplotlib
 seaborn  # For enhanced plotting (optional)
 scikit-learn  # Preparing for Phase 2 ML integration
 jupyter  # For analysis notebooks
+financedatabase

--- a/symbol_search.py
+++ b/symbol_search.py
@@ -1,0 +1,35 @@
+from financedatabase import Equities
+from functools import lru_cache
+import pandas as pd
+
+@lru_cache(maxsize=1)
+def _load_equities() -> pd.DataFrame:
+    """Load equity database for India once and cache it."""
+    eq = Equities()
+    return eq.select(country="India")
+
+def search_symbols(query: str, limit: int = 10) -> pd.DataFrame:
+    """Search Indian equities by symbol or name.
+
+    Parameters
+    ----------
+    query: str
+        Substring to search for.
+    limit: int
+        Maximum number of results to return.
+    """
+    if not query:
+        return pd.DataFrame()
+    df = _load_equities()
+    # Only keep symbols listed on NSE or BSE to ensure Fyers compatibility
+    df = df[df.index.str.endswith((".NS", ".BO"))]
+    mask = df.index.str.contains(query, case=False) | df["name"].str.contains(query, case=False)
+    return df[mask].head(limit)
+
+def to_fyers_symbol(symbol: str) -> str:
+    """Convert FinanceDatabase symbol to Fyers format."""
+    if symbol.endswith(".NS"):
+        return f"NSE:{symbol[:-3]}-EQ"
+    if symbol.endswith(".BO"):
+        return f"BSE:{symbol[:-3]}-EQ"
+    return symbol

--- a/templates/backtest.html
+++ b/templates/backtest.html
@@ -1,0 +1,89 @@
+<!doctype html>
+<html>
+<head>
+  <title>Strategy Backtest</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="p-4">
+  <div class="container">
+    <h1 class="mb-4">Strategy Backtest</h1>
+    <form method="post" class="row g-3">
+      <div class="col-md-3">
+        <label class="form-label">Symbol</label>
+        <div class="dropdown w-100">
+          <input id="backtestSymbol" name="symbol" class="form-control" value="{{ symbol }}" autocomplete="off">
+          <div id="backtest-symbol-dropdown" class="dropdown-menu w-100"></div>
+        </div>
+      </div>
+      <div class="col-md-3">
+        <label class="form-label">Resolution</label>
+        <select name="resolution" class="form-select">
+          {% for code, label in resolutions %}
+            <option value="{{ code }}" {% if code == default_resolution %}selected{% endif %}>{{ label }}</option>
+          {% endfor %}
+        </select>
+      </div>
+      <div class="col-md-3">
+        <label class="form-label">Start Date</label>
+        <input type="date" name="start_date" class="form-control" value="{{ start_date }}">
+      </div>
+      <div class="col-md-3">
+        <label class="form-label">End Date</label>
+        <input type="date" name="end_date" class="form-control" value="{{ end_date }}">
+      </div>
+      <div class="col-12">
+        <button class="btn btn-primary">Run Backtest</button>
+      </div>
+    </form>
+
+    {% if performance %}
+    <h2 class="mt-5">Performance</h2>
+    <table class="table table-striped">
+      <tr><th>Total Return</th><td>{{ '{:.2%}'.format(performance['total_return']) }}</td></tr>
+      <tr><th>Annual Return</th><td>{{ '{:.2%}'.format(performance['annual_return']) }}</td></tr>
+      <tr><th>Volatility</th><td>{{ '{:.2%}'.format(performance['volatility']) }}</td></tr>
+      <tr><th>Sharpe Ratio</th><td>{{ '{:.3f}'.format(performance['sharpe_ratio']) }}</td></tr>
+      <tr><th>Max Drawdown</th><td>{{ '{:.2%}'.format(performance['max_drawdown']) }}</td></tr>
+      <tr><th>Win Rate</th><td>{{ '{:.2%}'.format(performance['win_rate']) }}</td></tr>
+      <tr><th>Profit Factor</th><td>{{ '{:.2f}'.format(performance['profit_factor']) }}</td></tr>
+      <tr><th>Total Trades</th><td>{{ performance['total_trades'] }}</td></tr>
+    </table>
+    {% endif %}
+  </div>
+
+  <script>
+  const input = document.getElementById('backtestSymbol');
+  const dropdown = document.getElementById('backtest-symbol-dropdown');
+  input.addEventListener('input', async () => {
+    const q = input.value;
+    if (q.length < 2) {
+      dropdown.classList.remove('show');
+      return;
+    }
+    const res = await fetch(`/search-symbol?q=${encodeURIComponent(q)}`);
+    const data = await res.json();
+    dropdown.innerHTML = '';
+    data.forEach(item => {
+      const a = document.createElement('a');
+      a.classList.add('dropdown-item');
+      a.textContent = `${item.symbol} - ${item.name}`;
+      a.addEventListener('click', () => {
+        input.value = item.symbol;
+        dropdown.classList.remove('show');
+      });
+      dropdown.appendChild(a);
+    });
+    if (data.length) {
+      dropdown.classList.add('show');
+    } else {
+      dropdown.classList.remove('show');
+    }
+  });
+  document.addEventListener('click', (e) => {
+    if (!dropdown.contains(e.target) && e.target !== input) {
+      dropdown.classList.remove('show');
+    }
+  });
+  </script>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -33,8 +33,10 @@
                 <div class="col-md-6">
                   <div class="mb-3">
                     <label class="form-label">Symbol</label>
-                    <input name="symbol" class="form-control" value="{{ default_symbol }}" 
-                           placeholder="e.g., NSE:RELIANCE-EQ">
+                    <div class="dropdown w-100">
+                      <input id="symbolInput" name="symbol" class="form-control" value="{{ default_symbol }}" autocomplete="off" placeholder="e.g., NSE:RELIANCE-EQ">
+                      <div id="symbol-dropdown" class="dropdown-menu w-100"></div>
+                    </div>
                     <small class="form-text text-muted">Enter the symbol you want to analyze</small>
                   </div>
                 </div>
@@ -163,7 +165,42 @@
       form.action = '/';
       form.method = 'post';
       historicOptions.style.display = 'block';
+  });
+
+  // Symbol search suggestions dropdown
+  const symbolInput = document.getElementById('symbolInput');
+  const dropdown = document.getElementById('symbol-dropdown');
+  symbolInput.addEventListener('input', async () => {
+    const q = symbolInput.value;
+    if (q.length < 2) {
+      dropdown.classList.remove('show');
+      return;
+    }
+    const res = await fetch(`/search-symbol?q=${encodeURIComponent(q)}`);
+    const data = await res.json();
+    dropdown.innerHTML = '';
+    data.forEach(item => {
+      const a = document.createElement('a');
+      a.classList.add('dropdown-item');
+      a.textContent = `${item.symbol} - ${item.name}`;
+      a.addEventListener('click', () => {
+        symbolInput.value = item.symbol;
+        dropdown.classList.remove('show');
+      });
+      dropdown.appendChild(a);
     });
+    if (data.length) {
+      dropdown.classList.add('show');
+    } else {
+      dropdown.classList.remove('show');
+    }
+  });
+
+  document.addEventListener('click', (e) => {
+    if (!dropdown.contains(e.target) && e.target !== symbolInput) {
+      dropdown.classList.remove('show');
+    }
+  });
 
     liveOpt.addEventListener('change', () => {
       form.action = '/live';


### PR DESCRIPTION
## Summary
- add Flask endpoint to backtest strategies using existing StrategyBacktester
- integrate FinanceDatabase for symbol search with mapping to Fyers symbols
- expose symbol suggestions in dashboard and create dedicated backtest page
- show symbol suggestions in dropdowns and limit search results to NSE/BSE tickers
- handle Fyers API errors gracefully when symbols are invalid

## Testing
- `python -m py_compile app.py symbol_search.py strategy/backtesting.py`
- `python - <<'PY'
from symbol_search import search_symbols, to_fyers_symbol
print('RELIANCE search:\n', search_symbols('RELIANCE').head())
print('TTM search:\n', search_symbols('TTM'))
print('Mapping:', to_fyers_symbol('RELIANCE.NS'))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68adb313a6388325be9320c57b275784