### PR TITLE
Handle Fyers-style symbol queries

### DIFF
--- a/app.py
+++ b/app.py
@@ -218,12 +218,14 @@ def weights_management():
 @app.route('/search-symbol')
 def search_symbol_endpoint():
     """Provide symbol suggestions based on FinanceDatabase."""
-    query = request.args.get('q', '')
+    query = request.args.get('q', '').strip()
     results = []
     if query:
         df = search_symbols(query)
-        for sym, row in df.iterrows():
-            results.append({'symbol': to_fyers_symbol(sym), 'name': row.get('name', '')})
+        results = [
+            {'symbol': to_fyers_symbol(sym), 'name': row.get('name', '')}
+            for sym, row in df.iterrows()
+        ]
     return jsonify(results)
 
 

--- a/symbol_search.py
+++ b/symbol_search.py
@@ -20,10 +20,23 @@ def search_symbols(query: str, limit: int = 10) -> pd.DataFrame:
     """
     if not query:
         return pd.DataFrame()
+
     df = _load_equities()
     # Only keep symbols listed on NSE or BSE to ensure Fyers compatibility
-    df = df[df.index.str.endswith((".NS", ".BO"))]
-    mask = df.index.str.contains(query, case=False) | df["name"].str.contains(query, case=False)
+    df = df[df["exchange"].isin(["NSE", "BSE"])]
+
+    # Normalize Fyers-style inputs (e.g. "NSE:SBIN-EQ")
+    q = query.strip().upper()
+    for prefix in ("NSE:", "BSE:"):
+        if q.startswith(prefix):
+            q = q[len(prefix):]
+    if q.endswith("-EQ"):
+        q = q[:-3]
+
+    mask = (
+        df.index.str.contains(q, case=False, regex=False)
+        | df["name"].str.contains(q, case=False, regex=False)
+    )
     return df[mask].head(limit)
 
 def to_fyers_symbol(symbol: str) -> str:


### PR DESCRIPTION
## Summary
- Normalize Fyers-style prefixes/suffixes when searching FinanceDatabase
- Restrict symbol search to NSE and BSE via `exchange` column
- Trim query in `/search-symbol` endpoint

## Testing
- `python -m py_compile symbol_search.py app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0d07c1350832597e03725229b93b0